### PR TITLE
fix: detect fullscreen windows correctly

### DIFF
--- a/apps/moveFullscreenWindow.js
+++ b/apps/moveFullscreenWindow.js
@@ -37,7 +37,7 @@ class MoveFullscreenWindow {
         }
 
         // Check initial fullscreen state
-        if (window.fullscreen) {
+        if (window.is_fullscreen()) {
             this._onWindowFullscreenChanged(window);
         }
     }
@@ -52,7 +52,7 @@ class MoveFullscreenWindow {
     }
 
     _onWindowFullscreenChanged(window) {
-        if (window.fullscreen) {
+        if (window.is_fullscreen()) {
             // Move window to new workspace
             this._moveWindowToNewWorkspace(window);
         } else {


### PR DESCRIPTION
## Summary
- use `window.is_fullscreen()` to track fullscreen windows in moveFullscreenWindow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907da6545c832eb67299ae32167f4e