### PR TITLE
Fix typos across project documentation and strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Kiwi is not Apple
 
-Kiwi is a GNOME Shell extension that mimics various macOS features. This extension provides a collections of small quality of life functionalities such as moving windows to new workspaces, adding the username to the quick menu, focusing launched windows, and more.
+Kiwi is a GNOME Shell extension that mimics various macOS features. This extension provides a collection of small quality-of-life functionalities such as moving windows to new workspaces, adding the username to the quick menu, focusing launched windows, and more.
 
 
 ## Features
 
 - **Move Window to New Workspace**: Automatically move fullscreen app to new workspaces.
 - **Add Username to Quick Menu**: Display the username in the quick settings menu.
-- **Focus Launched Window**: Focus on newly launched windows. Removes annoying window ready notification.
-- **Lock Icon**: Display Caps lock or Num lock icon in Gnome top panel.
+- **Focus Launched Window**: Focus on newly launched windows. Removes the annoying window-ready notification.
+- **Lock Icon**: Display Caps Lock or Num Lock icon in the GNOME top panel.
 - **Transparent Move**: Make windows slightly transparent when moving.
 - **Battery Percentage**: Show battery percentage in the system menu when below 25%.
 
@@ -39,3 +39,4 @@ You can install the extension from the GNOME Extensions website:
 To build the extension, compile the GSettings schema:
 ```sh
 glib-compile-schemas schemas/
+```

--- a/apps/windowTitle.js
+++ b/apps/windowTitle.js
@@ -4,7 +4,7 @@ import GObject from 'gi://GObject';
 import Shell from 'gi://Shell';
 import St from 'gi://St';
 
-import {AppMenu} from 'resource:///org/gnome/shell/ui/appMenu.js';
+import { AppMenu } from 'resource:///org/gnome/shell/ui/appMenu.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
@@ -100,7 +100,7 @@ class WindowTitleIndicator extends PanelMenu.Button {
             return;
         }
 
-        // Exclude window titles that start with "com." or " gjs"
+        // Exclude window titles that start with "com." or "gjs"
         if (windowTitle.startsWith('com.') || windowTitle.includes('@!0,0')) {
             this._label.text = '';
             this._icon.gicon = null;

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "kiwi@kemma",
   "name": "Kiwi is not Apple",
-  "description": "Collection of various scripts that mimic MacOS features",
+  "description": "Collection of various scripts that mimic macOS features",
   "shell-version": ["45", "46", "47", "48"],
   "version": 0.1,
   "url": "https://github.com/kem-a/kiwi-kemma",

--- a/prefs.js
+++ b/prefs.js
@@ -11,7 +11,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
         const settings = this.getSettings();
         window._settings = settings;
-        window.title = 'Kiwi is not an Apple';
+        window.title = 'Kiwi is not Apple';
 
         // Settings Page
         const settingsPage = new Adw.PreferencesPage({
@@ -22,7 +22,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
 
         const group = new Adw.PreferencesGroup({
             title: _('Kiwi'),
-            description: _('Kiwi is not Apple is a collection of MacOS like features for GNOME'),
+            description: _('Kiwi is not Apple is a collection of macOS-like features for GNOME'),
         });
         settingsPage.add(group);
 
@@ -100,7 +100,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
 
         const buttonTypeGroup = new Adw.PreferencesGroup({
             title: _('Window Control Button Style'),
-            description: _('Select the style of window control buttons. NEED TO LOGOUT for effect to apply to all apps.'),
+            description: _('Select the style of window control buttons. You need to log out for the effect to apply to all apps.'),
         });
         settingsPage.add(buttonTypeGroup);
 
@@ -183,7 +183,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
         }));
 
         aboutBox.append(new Gtk.Label({
-            label: 'Kiwi is not Apple is a collection of MacOS like features for GNOME',
+            label: 'Kiwi is not Apple is a collection of macOS-like features for GNOME',
             halign: Gtk.Align.START,
         }));
 

--- a/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
@@ -35,7 +35,7 @@
       <key name="move-calendar-right" type="b">
         <default>false</default>
         <summary>Move Calendar to Right</summary>
-        <description>Move calendar to the right side of the top panel and hide notifications panel.</description>
+        <description>Move the calendar to the right side of the top panel and hide the notifications panel.</description>
       </key>
 
       <key name="transparent-on-moving" type="b">
@@ -61,7 +61,7 @@
       <key name="show-window-title" type="b">
         <default>true</default>
         <summary>Show window title in panel</summary>
-        <description>Display current window title in the top panel</description>
+        <description>Display the current window title in the top panel.</description>
       </key>
       <key name="show-window-controls" type="b">
         <default>false</default>
@@ -97,7 +97,7 @@
       <key name="hide-minimized-windows" type="b">
         <default>false</default>
         <summary>Hide minimized windows</summary>
-        <description>Hide minimized windows in the overview</description>
+        <description>Hide minimized windows in the overview.</description>
       </key>
       <key name="enable-app-window-buttons" type="b">
         <default>true</default>


### PR DESCRIPTION
## Summary
- tidy README wording and lock icon description
- standardize macOS references and improve preference text
- clarify schema descriptions and code comments

## Testing
- `codespell`
- `glib-compile-schemas schemas/`


------
https://chatgpt.com/codex/tasks/task_e_6890ac3999e4832e8c7ab212a36eb2ab