### PR TITLE
Align popup menu with window title

### DIFF
--- a/apps/windowTitle.js
+++ b/apps/windowTitle.js
@@ -3,6 +3,7 @@ import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';
 import Shell from 'gi://Shell';
 import St from 'gi://St';
+import GLib from 'gi://GLib';
 
 import { AppMenu } from 'resource:///org/gnome/shell/ui/appMenu.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -43,7 +44,10 @@ class WindowTitleIndicator extends PanelMenu.Button {
         
         this._onFocusedWindowChanged();
 
-        this.menu._arrowAlignment = 1.0;
+        this.connect('button-press-event', () => {
+            this._syncMenuAlignment();
+            return Clutter.EVENT_PROPAGATE;
+        });
 
         this._overviewHiddenId = Main.overview.connect('hidden',
             () => this._onOverviewHidden());
@@ -127,6 +131,24 @@ class WindowTitleIndicator extends PanelMenu.Button {
         if (!Main.overview.visible) {
             this.show();
         }
+
+        GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            this._syncMenuAlignment();
+            return GLib.SOURCE_REMOVE;
+        });
+    }
+
+    _syncMenuAlignment() {
+        const buttonBox = this.get_allocation_box();
+        const labelBox = this._label.get_allocation_box();
+        const buttonWidth = buttonBox.x2 - buttonBox.x1;
+
+        if (buttonWidth <= 0)
+            return;
+
+        const labelLeft = labelBox.x1 - buttonBox.x1;
+        const alignment = Math.max(0, Math.min(1, labelLeft / buttonWidth));
+        this._menu._arrowAlignment = alignment;
     }
 
     destroy() {


### PR DESCRIPTION
## Summary
- Dynamically compute menu arrow alignment so the popup menu opens at the same left offset as the window title
- Recalculate alignment on title updates using GLib idle callbacks

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a79256e258832ea74b101aab31bebd