### PR TITLE
Add GPL SPDX headers to scripts and assets

### DIFF
--- a/advanced/compile-extra.sh
+++ b/advanced/compile-extra.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # compile-extra.sh - Compile the Kiwi titlebuttons hover module from source
 

--- a/advanced/convert-svg.sh
+++ b/advanced/convert-svg.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # Check if rsvg-convert is available
 if ! command -v rsvg-convert &> /dev/null; then

--- a/advanced/install-extra.sh
+++ b/advanced/install-extra.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # install-extra.sh - Install the Kiwi titlebuttons hover module
 

--- a/advanced/relink.sh
+++ b/advanced/relink.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # base size 16px
 

--- a/advanced/uninstall-extra.sh
+++ b/advanced/uninstall-extra.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 # uninstall-extra.sh - Uninstall the Kiwi titlebuttons hover module
 

--- a/apps/addUsernameToQuickMenu.js
+++ b/apps/addUsernameToQuickMenu.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // addUsernameToQuickMenu.js
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';

--- a/apps/batteryPercentage.js
+++ b/apps/batteryPercentage.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // batteryPercentage.js - Updated for GNOME 45+
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';

--- a/apps/calendar.js
+++ b/apps/calendar.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import Clutter from 'gi://Clutter';
 import St from 'gi://St';

--- a/apps/firefoxThemeManager.js
+++ b/apps/firefoxThemeManager.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // firefoxThemeManager.js - Manages Firefox userChrome.css based on settings
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';

--- a/apps/focusLaunchedWindow.js
+++ b/apps/focusLaunchedWindow.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // focusLaunchedWindow.js
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 

--- a/apps/gtkThemeManager.js
+++ b/apps/gtkThemeManager.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // gtkThemeManager.js - Manages GTK CSS imports based on settings
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';

--- a/apps/hideActivitiesButton.js
+++ b/apps/hideActivitiesButton.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // hideActivitiesButton.js - Hide the Activities button in the top panel
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 

--- a/apps/hideMinimizedWindows.js
+++ b/apps/hideMinimizedWindows.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import { Workspace } from 'resource:///org/gnome/shell/ui/workspace.js';
 import {
     GroupCyclerPopup,

--- a/apps/keyboardIndicator.js
+++ b/apps/keyboardIndicator.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // keyboardIndicator.js - Simple control for panel keyboard/input source indicator
 import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';

--- a/apps/lockIcon.js
+++ b/apps/lockIcon.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // lockIcon.js
 import St from 'gi://St';
 import Clutter from 'gi://Clutter';

--- a/apps/moveFullscreenWindow.js
+++ b/apps/moveFullscreenWindow.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // moveFullscreenWindow.js
 // NOTE: Previous implementation stored raw Meta.Workspace objects on windows and
 // removed "empty" workspaces immediately on fullscreen exit. Under certain

--- a/apps/overviewWallpaper.js
+++ b/apps/overviewWallpaper.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import St from 'gi://St';

--- a/apps/panelHover.js
+++ b/apps/panelHover.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import St from 'gi://St';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';

--- a/apps/panelTransparency.js
+++ b/apps/panelTransparency.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // panelTransparency.js - Panel Transparency Extension
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import GLib from 'gi://GLib';

--- a/apps/skipOverviewOnLogin.js
+++ b/apps/skipOverviewOnLogin.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 let startupId = 0;

--- a/apps/transparentMove.js
+++ b/apps/transparentMove.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // transparentMove.js
 import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';

--- a/apps/windowControls.js
+++ b/apps/windowControls.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // windowControls.js - Adds window controls to the top panel
 import GObject from 'gi://GObject';
 import Gio from 'gi://Gio';

--- a/apps/windowTitle.js
+++ b/apps/windowTitle.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 // windowTitle.js - Display the title of the focused window in the top panel
 import Clutter from 'gi://Clutter';
 import GObject from 'gi://GObject';

--- a/icons/firefoxWindowControls.alt.css
+++ b/icons/firefoxWindowControls.alt.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Firefox Window Controls Theming (Kiwi - default set) */
 @namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 

--- a/icons/firefoxWindowControls.css
+++ b/icons/firefoxWindowControls.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Firefox Window Controls Theming (Kiwi - default set) */
 @namespace xul "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 

--- a/icons/firefoxWindowControlsHidden.css
+++ b/icons/firefoxWindowControlsHidden.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Firefox Hide Window Controls when Maximized (Kiwi) */
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 

--- a/icons/fixes3.css
+++ b/icons/fixes3.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /*(((((((((( Other fixes  ))))))))))))*/
 
 /* GTK3 button padding fix to match with GTK4 */

--- a/icons/fixes4.css
+++ b/icons/fixes4.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /*(((((((((( Other fixes  ))))))))))))*/
 
 /* Nautilus list view fix to reduce padding */

--- a/icons/gtk3.css
+++ b/icons/gtk3.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 @import 'titlebuttons3.css';
 @import 'hide-titlebar3.css';
 

--- a/icons/gtk4.css
+++ b/icons/gtk4.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 @import 'titlebuttons4.css';
 @import 'hide-titlebar4.css';
 

--- a/icons/hide-titlebar3.css
+++ b/icons/hide-titlebar3.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Hide GTK3 window control buttons (and left box) when maximized or fullscreen */
 
 .maximized headerbar .titlebutton,

--- a/icons/hide-titlebar4.css
+++ b/icons/hide-titlebar4.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Hide GTK4 app titlebar and buttons when maximized */
 
 /* Completely hide the titlebar when maximized and in fullscreen*/

--- a/icons/titlebuttons-alt3.css
+++ b/icons/titlebuttons-alt3.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Custom theme GTK3 - Window Controls Mac-like Behavior
  * Updated to use pre-rendered PNG assets + @2 hi-DPI counterparts.
  * Rationale: GTK3 also exhibits soft / blurry rasterization of SVG

--- a/icons/titlebuttons-alt4.css
+++ b/icons/titlebuttons-alt4.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Custom theme GTK4 - Window Controls Mac-like Behavior */
 
 /* Window Controls base states*/

--- a/icons/titlebuttons3.css
+++ b/icons/titlebuttons3.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Custom theme GTK3 - Window Controls Mac-like Behavior
  * Updated to use pre-rendered PNG assets + @2 hi-DPI counterparts.
  * Rationale: GTK3 also exhibits soft / blurry rasterization of SVG

--- a/icons/titlebuttons4.css
+++ b/icons/titlebuttons4.css
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+
 /* Custom theme GTK4 - Window Controls Mac-like Behavior */
 
 /* Window Controls base states*/


### PR DESCRIPTION
## Summary
- add GPL-3.0-or-later SPDX headers to all JavaScript modules in apps
- add GPL-3.0-or-later SPDX headers to icon CSS stylesheets
- insert GPL-3.0-or-later SPDX headers into advanced shell scripts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4f5b23864832e85de27859d76d23d