### PR TITLE
Fix panel background issue in dark themes (Fixes #18)

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -50,6 +50,7 @@
   box-shadow: 0 5px 16px rgba(0, 0, 0, 0.05);
   transition-property: background-color;
   transition-timing-function: ease-out;
+  background-color: inherit;
 }
 
 #panel .panel-button {


### PR DESCRIPTION
This commit set panel background color as inherit, so attributes are being loaading as expected.

Before:
<img width="302" height="148" alt="before" src="https://github.com/user-attachments/assets/ba8af63f-37ef-4373-8ca5-369fd786d82d" />

After:
![WhatsApp Image 2025-09-29 at 14 13 55](https://github.com/user-attachments/assets/4b2c760f-840e-4829-843b-330aab5e8963)
