### PR TITLE
Gnome51 fixes

### DIFF
--- a/apps/dockBlur.js
+++ b/apps/dockBlur.js
@@ -160,21 +160,34 @@ function _tryBlurDock(dockContainer) {
     };
     updateSize();
 
+    // Resizing our widgets straight from a layout notification re-enters the
+    // layout phase and makes the shell warn about actors needing an
+    // allocation. Coalesce into an idle so it runs after layout settles.
+    let updateIdleId = 0;
+    const queueUpdateSize = () => {
+        if (updateIdleId) return;
+        updateIdleId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+            updateIdleId = 0;
+            updateSize();
+            return GLib.SOURCE_REMOVE;
+        });
+    };
+
     const signals = [];
     // Allocation signals catch geometry settling that the x/y/width/height
     // notifications can miss (dock created mid-layout, resume from sleep).
-    signals.push({ actor: dash, id: dash.connect('notify::allocation', updateSize) });
-    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::allocation', updateSize) });
-    signals.push({ actor: dash, id: dash.connect('notify::width', updateSize) });
-    signals.push({ actor: dash, id: dash.connect('notify::height', updateSize) });
-    signals.push({ actor: dash, id: dash.connect('notify::y', updateSize) });
-    signals.push({ actor: dash, id: dash.connect('notify::x', updateSize) });
-    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::width', updateSize) });
-    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::height', updateSize) });
-    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::x', updateSize) });
-    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::y', updateSize) });
-    signals.push({ actor: dockContainer, id: dockContainer.connect('notify::width', updateSize) });
-    signals.push({ actor: dockContainer, id: dockContainer.connect('notify::height', updateSize) });
+    signals.push({ actor: dash, id: dash.connect('notify::allocation', queueUpdateSize) });
+    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::allocation', queueUpdateSize) });
+    signals.push({ actor: dash, id: dash.connect('notify::width', queueUpdateSize) });
+    signals.push({ actor: dash, id: dash.connect('notify::height', queueUpdateSize) });
+    signals.push({ actor: dash, id: dash.connect('notify::y', queueUpdateSize) });
+    signals.push({ actor: dash, id: dash.connect('notify::x', queueUpdateSize) });
+    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::width', queueUpdateSize) });
+    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::height', queueUpdateSize) });
+    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::x', queueUpdateSize) });
+    signals.push({ actor: dashBackground, id: dashBackground.connect('notify::y', queueUpdateSize) });
+    signals.push({ actor: dockContainer, id: dockContainer.connect('notify::width', queueUpdateSize) });
+    signals.push({ actor: dockContainer, id: dockContainer.connect('notify::height', queueUpdateSize) });
 
     const info = {
         dockContainer,
@@ -186,6 +199,12 @@ function _tryBlurDock(dockContainer) {
         blurEffect,
         signals,
         destroyId: null,
+        cancelUpdate: () => {
+            if (updateIdleId) {
+                GLib.Source.remove(updateIdleId);
+                updateIdleId = 0;
+            }
+        },
     };
 
     // Auto-cleanup if the dash is destroyed (user disables dock extension)
@@ -199,6 +218,8 @@ function _tryBlurDock(dockContainer) {
 }
 
 function _removeDashBlur(info, disconnectDestroy = true) {
+    info.cancelUpdate();
+
     // Disconnect size signals
     for (const { actor, id } of info.signals) {
         try { actor.disconnect(id); } catch (_) {}

--- a/apps/minimizedToDock.js
+++ b/apps/minimizedToDock.js
@@ -7,6 +7,7 @@
 // the macOS order (apps | minimized windows | trash) without reimplementing it.
 
 import Clutter from 'gi://Clutter';
+import Cogl from 'gi://Cogl';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
@@ -157,30 +158,55 @@ function _holdGeometry(win) {
 
 /* ------------------------------------------------------------------ tiles */
 
-// Alpha to zero outside the corner arcs, with a half-pixel feather so the
-// curve does not stair-step. Clutter binds the source texture to 'tex' itself.
+const CORNER_UNIFORMS = `
+    uniform float width;
+    uniform float height;
+    uniform float radius;
+`;
+// Alpha to zero outside the corner arcs, with a half-pixel feather so the curve
+// does not stair-step. Leaves the coverage in 'a'.
+const CORNER_COVERAGE = `
+    vec2 size = vec2(width, height);
+    vec2 uv = cogl_tex_coord_in[0].xy;
+    // How far the pixel reaches past the corner arc, 0 while inside
+    vec2 d = max(vec2(radius) - min(uv * size, size - uv * size), vec2(0.0));
+    float a = clamp(radius - length(d) + 0.5, 0.0, 1.0);
+`;
+
+// GNOME 48-50, where the effect replaces the fragment program outright and
+// Clutter binds the source texture to 'tex' itself.
 const RoundedCornersEffect = GObject.registerClass(
 class RoundedCornersEffect extends Clutter.ShaderEffect {
     constructor() {
         super();
         this.set_shader_source(`
             uniform sampler2D tex;
-            uniform float width;
-            uniform float height;
-            uniform float radius;
+            ${CORNER_UNIFORMS}
 
             void main() {
-                vec2 size = vec2(width, height);
-                vec2 uv = cogl_tex_coord_in[0].xy;
-                // How far the pixel reaches past the corner arc, 0 while inside
-                vec2 d = max(vec2(radius) - min(uv * size, size - uv * size),
-                             vec2(0.0));
-                float a = clamp(radius - length(d) + 0.5, 0.0, 1.0);
+                ${CORNER_COVERAGE}
                 cogl_color_out = texture2D(tex, uv) * a;
             }
         `);
     }
 });
+
+/**
+ * GNOME 51 dropped Clutter.ShaderEffect.set_shader_source: a shader effect is
+ * now built from a Cogl snippet, which hooks into the pipeline instead of
+ * replacing it. The fragment stage has therefore already sampled the actor into
+ * cogl_color_out by the time the snippet runs, and all it has to do is scale it.
+ */
+function _newRoundedCornersEffect() {
+    if (Clutter.ShaderEffect.prototype.set_shader_source)
+        return new RoundedCornersEffect();
+
+    return Clutter.ShaderEffect.new_with_snippet(
+        Cogl.Snippet.new(Cogl.SnippetHook.FRAGMENT, CORNER_UNIFORMS, `
+            ${CORNER_COVERAGE}
+            cogl_color_out *= a;
+        `));
+}
 
 function _scaleFactor() {
     return St.ThemeContext.get_for_stage(global.stage).scaleFactor;
@@ -202,7 +228,7 @@ function _tileBox(dash) {
  * @param actor the thumbnail actor, already at its final size
  */
 function _roundCorners(actor) {
-    const effect = new RoundedCornersEffect();
+    const effect = _newRoundedCornersEffect();
     actor.add_effect(effect);
 
     const { width, height } = actor;

--- a/apps/minimizedToDock.js
+++ b/apps/minimizedToDock.js
@@ -45,9 +45,8 @@ let d2dSettings = null;
 const sources = { dockSearch: 0, restoreGrace: 0, geometryUpdate: 0, trashAdoption: 0 };
 
 function _disconnectAll(pairs) {
-    for (const [object, id] of pairs) {
-        try { object.disconnect(id); } catch (_) {}
-    }
+    for (const [object, id] of pairs)
+        object.disconnect(id);
 }
 
 /* -------------------------------------------------------------- snapshots */
@@ -747,6 +746,8 @@ function _watchDocks() {
     // The dock may still be loading, retry for a while
     if (docks.length === 0) {
         let attempts = 0;
+        if (sources.dockSearch)
+            GLib.Source.remove(sources.dockSearch);
         sources.dockSearch = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, () => {
             _attachExistingDocks();
             if (docks.length > 0 || ++attempts >= 10) {
@@ -759,8 +760,6 @@ function _watchDocks() {
 }
 
 export function disable() {
-    if (!enabled)
-        return;
     enabled = false;
 
     for (const key of Object.keys(sources)) {
@@ -774,15 +773,12 @@ export function disable() {
 
     [...docks].forEach(info => _detachDock(info));
 
-    // Drop our animation targets; Dash-to-Dock repoints them at its app icons
-    // on its next update
-    global.get_window_actors().forEach(actor => {
-        if (_isEligible(actor.meta_window))
-            actor.meta_window.set_icon_geometry(null);
-    });
-
-    for (const [win, ids] of windowSignals)
+    for (const [win, ids] of windowSignals) {
         _disconnectAll(ids.map(id => [win, id]));
+        // Drop our animation targets; Dash-to-Dock repoints them at its app
+        // icons on its next update
+        win.set_icon_geometry(null);
+    }
     windowSignals.clear();
     snapshots.clear();
     restoring.clear();

--- a/apps/minimizedToDock.js
+++ b/apps/minimizedToDock.js
@@ -238,6 +238,15 @@ function _roundCorners(actor) {
     effect.set_uniform_value('width', width - 1e-6);
     effect.set_uniform_value('height', height - 1e-6);
     effect.set_uniform_value('radius', radius - 1e-6);
+
+    // A dash item's preferred size follows its scale, so an animating tile
+    // allocates its thumbnail down to nothing. An offscreen effect on a
+    // zero-sized actor asks Cogl for an empty viewport, which it warns about;
+    // there is nothing to round off at that size anyway.
+    actor.connect('notify::allocation', () => {
+        const box = actor.get_allocation_box();
+        effect.enabled = box.get_width() >= 1 && box.get_height() >= 1;
+    });
 }
 
 /**

--- a/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
@@ -7,12 +7,12 @@
         <description>Enable or disable moving windows to new workspaces.</description>
       </key>
       <key name="add-username-to-quick-menu" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Add Username to Quick Menu</summary>
         <description>Enable or disable adding the username to the quick menu.</description>
       </key>
       <key name="lock-icon" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Lock Icon</summary>
         <description>Enable or disable the lock icon.</description>
       </key>
@@ -104,7 +104,7 @@
         <description>Make the top panel transparent.</description>
       </key>
       <key name="panel-transparency-level" type="i">
-        <default>50</default>
+        <default>30</default>
         <range min="0" max="100"/>
         <summary>Panel Transparency Level</summary>
         <description>Set the transparency level of the panel (0-100).</description>
@@ -142,7 +142,7 @@
       
       <!-- Keyboard indicator controls -->
       <key name="keyboard-indicator" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Keyboard Indicator Styling</summary>
         <description>Enable additional options for the panel keyboard/input source indicator.</description>
       </key>
@@ -175,21 +175,21 @@
 
       <!-- Panel blur -->
       <key name="panel-blur" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Panel Blur</summary>
         <description>Apply a blur effect behind the top panel when it is transparent.</description>
       </key>
       
       <!-- Dock blur -->
       <key name="dock-blur" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Dock Blur</summary>
         <description>Apply a blur effect behind the Dash-to-Dock background.</description>
       </key>
 
       <!-- Minimized windows in the dock -->
       <key name="minimize-to-dock" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Minimize Windows to Dock</summary>
         <description>Park minimized windows as thumbnails in Dash-to-Dock, after the apps and before the trash.</description>
       </key>
@@ -216,7 +216,7 @@
 
       <!-- Reduce window open/close animations -->
       <key name="reduce-window-animations" type="b">
-        <default>false</default>
+        <default>true</default>
         <summary>Reduce Window Open/Close Animations</summary>
         <description>Replace the default window opening and closing animation with a subtle macOS-style scale and fade.</description>
       </key>


### PR DESCRIPTION
Gnomeregan strikes again. GNOME 51 dropped Clutter.ShaderEffect.set_shader_source. 