### PR TITLE
Monochrome icons follow theme

### DIFF
--- a/apps/panelTransparency.js
+++ b/apps/panelTransparency.js
@@ -384,15 +384,28 @@ function updateForegroundContrast(opacity) {
 }
 
 // Panel color fix helper
+// The class only sets the panel's *theme* background; the colour that actually
+// shows comes from the inline style updatePanelStyle() builds out of
+// get_background_color(). So toggling the class changes nothing until the stale
+// inline style is dropped and the style recomputed — that is why the old
+// behaviour needed an overview trip (which clears the inline style) to show up.
 function applyPanelColorFix() {
     const panel = Main.panel;
     if (!panel) return;
-    
+
     if (settings && settings.get_boolean('panel-color-inherit')) {
         panel.add_style_class_name('kiwi-panel-color-inherit');
     } else {
         panel.remove_style_class_name('kiwi-panel-color-inherit');
     }
+
+    // Clear the inline background so the theme node reports the class colour
+    // instead of the rgba() we last wrote, then rebuild it from that reading.
+    panel.set_style('');
+    GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+        if (enabled) updatePanelStyle(lastForcedAlpha);
+        return GLib.SOURCE_REMOVE;
+    });
 }
 
 // Transparency is off: hand the panel back to whatever styled it before us.

--- a/apps/panelTransparency.js
+++ b/apps/panelTransparency.js
@@ -7,6 +7,8 @@ import St from 'gi://St';
 import Gio from 'gi://Gio';
 import Meta from 'gi://Meta';
 import Shell from 'gi://Shell';
+import GdkPixbuf from 'gi://GdkPixbuf';
+import Clutter from 'gi://Clutter';
 
 import { connectPaintSignal } from './blurPaintSignal.js';
 
@@ -22,6 +24,24 @@ let timeoutId;
 let safetyIntervalId;
 let lastForcedAlpha = null; // remember last alpha decided by logic (touch/fullscreen)
 let lastFullscreenState = false; // edge-detect fullscreen state changes
+
+// Adaptive foreground state
+let bgSettings;
+let bgSignals = [];
+let wallpaperIsLight = false;
+let iconTheme;
+let monochromeIcons = new Map(); // gicon string -> whether inverting it is safe
+
+// Below this panel opacity the wallpaper dominates, so the foreground has to
+// follow the wallpaper instead of the theme.
+const ADAPTIVE_OPACITY_MAX = 0.3;
+const SAMPLE_SIZE = 32; // wallpaper is downscaled to this before sampling
+const SAMPLE_ROWS = 4;  // top rows only — that's what sits behind the panel
+const LIGHT_THRESHOLD = 0.6;
+const INVERT_EFFECT = 'kiwi-tray-invert';
+const ICON_SAMPLE_SIZE = 24;
+const ICON_SATURATION_MAX = 0.15; // above this the icon carries real colour
+const ICON_LUMINANCE_MIN = 0.6;   // below this it is already dark enough
 
 // Blur state
 let blurEffect = null;
@@ -211,6 +231,158 @@ function updateBlurVisibility(visible) {
     }
 }
 
+// --- Adaptive foreground helpers ---
+// A nearly transparent panel shows the wallpaper, so white text on a light
+// wallpaper is unreadable. Sample the strip of the wallpaper that sits behind
+// the panel and flip the foreground to dark when that strip is light.
+
+function _wallpaperPath() {
+    if (!bgSettings) return null;
+    const dark = interfaceSettings?.get_string('color-scheme') === 'prefer-dark';
+    let uri = dark ? bgSettings.get_string('picture-uri-dark') : '';
+    if (!uri) uri = bgSettings.get_string('picture-uri');
+    if (!uri) return null;
+    return Gio.File.new_for_uri(uri).get_path();
+}
+
+function updateWallpaperLightness() {
+    const path = _wallpaperPath();
+    if (!path) {
+        wallpaperIsLight = false;
+        return;
+    }
+
+    try {
+        // preserve_aspect_ratio false: SAMPLE_ROWS is then a fixed fraction of
+        // the image height regardless of its dimensions.
+        const pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(path, SAMPLE_SIZE, SAMPLE_SIZE, false);
+        const pixels = pixbuf.get_pixels();
+        const stride = pixbuf.get_rowstride();
+        const channels = pixbuf.get_n_channels();
+        const width = pixbuf.get_width();
+        const rows = Math.min(SAMPLE_ROWS, pixbuf.get_height());
+
+        let sum = 0;
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < width; x++) {
+                const i = y * stride + x * channels;
+                sum += (0.2126 * pixels[i] + 0.7152 * pixels[i + 1] + 0.0722 * pixels[i + 2]) / 255;
+            }
+        }
+        wallpaperIsLight = (sum / (rows * width)) > LIGHT_THRESHOLD;
+    } catch (_e) {
+        // XML slideshows and unreadable files: keep the theme foreground
+        wallpaperIsLight = false;
+    }
+}
+
+// Tray icons come from apps as raster images, so CSS can't recolour them.
+// Brightness -1 maps every pixel to black and leaves alpha alone, which turns a
+// white monochrome icon dark. A coloured icon would just become a dark blob, so
+// only icons that measure as monochrome and light get the effect.
+function _measureIcon(pixbuf) {
+    const pixels = pixbuf.get_pixels();
+    const stride = pixbuf.get_rowstride();
+    const channels = pixbuf.get_n_channels();
+    const width = pixbuf.get_width();
+    const height = pixbuf.get_height();
+
+    let saturation = 0;
+    let luminance = 0;
+    let count = 0;
+
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            const i = y * stride + x * channels;
+            if (pixels[i + 3] < 30) continue; // ignore near-transparent pixels
+
+            const r = pixels[i] / 255, g = pixels[i + 1] / 255, b = pixels[i + 2] / 255;
+            const max = Math.max(r, g, b), min = Math.min(r, g, b);
+
+            saturation += max === 0 ? 0 : (max - min) / max;
+            luminance += 0.2126 * r + 0.7152 * g + 0.0722 * b;
+            count++;
+        }
+    }
+
+    if (!count) return false;
+    return (saturation / count) < ICON_SATURATION_MAX &&
+           (luminance / count) > ICON_LUMINANCE_MIN;
+}
+
+function _shouldInvertIcon(gicon) {
+    if (!gicon) return false;
+
+    // AppIndicator wraps file icons in an EmblemedIcon that deliberately breaks
+    // to_string(); the inner icon resolves and keys the cache properly.
+    if (gicon instanceof Gio.EmblemedIcon)
+        gicon = gicon.get_icon();
+
+    const key = gicon.to_string();
+    if (key && monochromeIcons.has(key))
+        return monochromeIcons.get(key);
+
+    let invert = false;
+    try {
+        const info = iconTheme.lookup_by_gicon(gicon, ICON_SAMPLE_SIZE, St.IconLookupFlags.FORCE_SIZE);
+        const pixbuf = info?.load_icon();
+        // Without an alpha channel the icon is a solid rectangle — inverting it
+        // would produce exactly the dark patch this check exists to avoid.
+        if (pixbuf?.get_has_alpha())
+            invert = _measureIcon(pixbuf);
+    } catch (_e) {
+        // Unresolvable icon: leave it alone
+    }
+
+    if (key) monochromeIcons.set(key, invert);
+    return invert;
+}
+
+function _trayIcons() {
+    const icons = [];
+    const walk = actor => {
+        for (const child of actor.get_children()) {
+            if (child instanceof St.Icon &&
+                (child.has_style_class_name('appindicator-icon') || child.has_style_class_name('tray-icon')))
+                icons.push(child);
+            else
+                walk(child);
+        }
+    };
+    walk(Main.panel);
+    return icons;
+}
+
+function updateTrayIconInversion(enabled) {
+    for (const icon of _trayIcons()) {
+        const applied = icon.get_effect(INVERT_EFFECT) !== null;
+        // An icon painted from a D-Bus pixmap carries its image in `content`,
+        // and the gicon left over from an earlier update may not match it.
+        // Measuring the gicon would then judge an image that isn't on screen.
+        const invert = enabled && !icon.content && _shouldInvertIcon(icon.gicon);
+        if (invert && !applied) {
+            const effect = new Clutter.BrightnessContrastEffect({ name: INVERT_EFFECT });
+            effect.set_brightness(-1.0);
+            icon.add_effect(effect);
+        } else if (!invert && applied) {
+            icon.remove_effect_by_name(INVERT_EFFECT);
+        }
+    }
+}
+
+function updateForegroundContrast(opacity) {
+    const panel = Main.panel;
+    const dark = wallpaperIsLight && opacity < ADAPTIVE_OPACITY_MAX;
+
+    if (dark)
+        panel.add_style_class_name('kiwi-panel-dark-text');
+    else
+        panel.remove_style_class_name('kiwi-panel-dark-text');
+
+    // Indicators that appear later are picked up by the periodic safety check.
+    updateTrayIconInversion(dark && settings?.get_boolean('panel-invert-tray-icons'));
+}
+
 // Panel color fix helper
 function applyPanelColorFix() {
     const panel = Main.panel;
@@ -275,6 +447,7 @@ function updatePanelStyle(alpha = null) {
         if (Main.overview.visible) {
             panel.set_style('background-color: transparent !important;');
             updateBlurVisibility(false);
+            updateForegroundContrast(1.0);
             panel.queue_redraw();
             return;
         }
@@ -284,12 +457,14 @@ function updatePanelStyle(alpha = null) {
             // Clear any inline style to let CSS rule take effect
             panel.set_style('');
             updateBlurVisibility(false);
+            updateForegroundContrast(1.0);
             panel.queue_redraw();
             return;
         }
 
         if (!settings?.get_boolean('panel-transparency')) {
             updateBlurVisibility(false);
+            updateForegroundContrast(1.0);
             restorePanelStyle();
             return;
         }
@@ -312,6 +487,7 @@ function updatePanelStyle(alpha = null) {
         // Show/hide blur regardless of whether style string changed
         const blurEnabled = settings?.get_boolean('panel-blur');
         updateBlurVisibility(blurEnabled && opacity < 1.0);
+        updateForegroundContrast(opacity);
 
         if (panel.get_style() !== newStyle) {
             panel.set_style(newStyle);
@@ -462,6 +638,9 @@ function setupSignals() {
         settings.connect('changed::panel-color-inherit', () => {
             applyPanelColorFix();
         }),
+        settings.connect('changed::panel-invert-tray-icons', () => {
+            updatePanelStyle(null);
+        }),
         settings.connect('changed::panel-blur', () => {
             if (settings.get_boolean('panel-blur')) {
                 createBlurEffect();
@@ -561,12 +740,22 @@ export function enable(_settings) {
     originalStyle = Main.panel.get_style();
     interfaceSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.interface' });
     interfaceSettingsSignal = interfaceSettings.connect('changed::color-scheme', () => {
+        updateWallpaperLightness();
         forceThemeUpdate();
         GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
             updatePanelStyle();
             return GLib.SOURCE_REMOVE;
         });
     });
+
+    iconTheme = new St.IconTheme();
+    bgSettings = new Gio.Settings({ schema_id: 'org.gnome.desktop.background' });
+    bgSignals = ['changed::picture-uri', 'changed::picture-uri-dark'].map(key =>
+        bgSettings.connect(key, () => {
+            updateWallpaperLightness();
+            updatePanelStyle();
+        }));
+    updateWallpaperLightness();
 
     setupSignals();
 
@@ -621,6 +810,13 @@ export function disable() {
     }
     interfaceSettings = null;
 
+    bgSignals.forEach(signal => bgSettings.disconnect(signal));
+    bgSignals = [];
+    bgSettings = null;
+    wallpaperIsLight = false;
+    iconTheme = null;
+    monochromeIcons.clear();
+
     // Destroy blur effect
     destroyBlurEffect();
 
@@ -628,6 +824,8 @@ export function disable() {
     const panel = Main.panel;
     panel.remove_style_class_name('kiwi-panel-fullscreen');
     panel.remove_style_class_name('kiwi-panel-color-inherit');
+    panel.remove_style_class_name('kiwi-panel-dark-text');
+    updateTrayIconInversion(false);
     restorePanelStyle();
 
     settings = null;

--- a/apps/panelTransparency.js
+++ b/apps/panelTransparency.js
@@ -31,6 +31,7 @@ let bgSignals = [];
 let wallpaperIsLight = false;
 let iconTheme;
 let monochromeIcons = new Map(); // gicon string -> whether inverting it is safe
+let contentIcons = new WeakMap(); // St.ImageContent -> whether inverting it is safe
 
 // Below this panel opacity the wallpaper dominates, so the foreground has to
 // follow the wallpaper instead of the theme.
@@ -338,6 +339,31 @@ function _shouldInvertIcon(gicon) {
     return invert;
 }
 
+// Indicators that publish IconPixmap over D-Bus instead of an icon name (the
+// Nextcloud client, for one) have nothing to look up: AppIndicator paints the
+// pixmap straight into an St.ImageContent and leaves the gicon behind. That
+// content is a Gio.LoadableIcon, so the image actually on screen can be read
+// back and measured with the same test — AppIndicator itself loads it this way
+// to build emblems. A new St.ImageContent is created for every pixmap update,
+// so keying the cache on the object both caches and invalidates itself.
+function _shouldInvertContent(content) {
+    if (contentIcons.has(content))
+        return contentIcons.get(content);
+
+    let invert = false;
+    try {
+        const [stream] = content.load(ICON_SAMPLE_SIZE, null);
+        const pixbuf = GdkPixbuf.Pixbuf.new_from_stream(stream, null);
+        if (pixbuf?.get_has_alpha())
+            invert = _measureIcon(pixbuf);
+    } catch (_e) {
+        // Unreadable content: leave it alone
+    }
+
+    contentIcons.set(content, invert);
+    return invert;
+}
+
 function _trayIcons() {
     const icons = [];
     const walk = actor => {
@@ -357,9 +383,11 @@ function updateTrayIconInversion(enabled) {
     for (const icon of _trayIcons()) {
         const applied = icon.get_effect(INVERT_EFFECT) !== null;
         // An icon painted from a D-Bus pixmap carries its image in `content`,
-        // and the gicon left over from an earlier update may not match it.
-        // Measuring the gicon would then judge an image that isn't on screen.
-        const invert = enabled && !icon.content && _shouldInvertIcon(icon.gicon);
+        // and the gicon left over from an earlier update may not match it, so
+        // measure whichever of the two is the image actually on screen.
+        const invert = enabled && (icon.content
+            ? _shouldInvertContent(icon.content)
+            : _shouldInvertIcon(icon.gicon));
         if (invert && !applied) {
             const effect = new Clutter.BrightnessContrastEffect({ name: INVERT_EFFECT });
             effect.set_brightness(-1.0);
@@ -829,6 +857,7 @@ export function disable() {
     wallpaperIsLight = false;
     iconTheme = null;
     monochromeIcons.clear();
+    contentIcons = new WeakMap();
 
     // Destroy blur effect
     destroyBlurEffect();

--- a/prefs.js
+++ b/prefs.js
@@ -63,7 +63,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
         const settings = this.getSettings();
         window._settings = settings;
-        const extensionTitle = _('Kiwi is not Apple');
+        const extensionTitle = _('Kiwi (is not Apple)');
         window.title = extensionTitle;
         window.set_default_size(510, 710);
         // Enable built-in libadwaita search (adds search button automatically)
@@ -233,7 +233,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
             // License section
             const licenseGroup = new Adw.PreferencesGroup({
                 title: _('License'),
-                description: _('Kiwi is not Apple is free and open source software'),
+                description: _('Kiwi is free and open source software'),
             });
 
             // GPL License link
@@ -669,7 +669,8 @@ export default class KiwiPreferences extends ExtensionPreferences {
             settings.get_int('panel-transparency-level') !== 50 ||
             settings.get_boolean('panel-opaque-on-window') ||
             settings.get_boolean('panel-blur') ||
-            settings.get_boolean('panel-color-inherit');
+            settings.get_boolean('panel-color-inherit') ||
+            settings.get_boolean('panel-invert-tray-icons');
         const transparencyExpander = new Adw.ExpanderRow({
             title: _("Panel Transparency"),
             subtitle: _("Make the top panel transparent"),
@@ -719,6 +720,15 @@ export default class KiwiPreferences extends ExtensionPreferences {
         });
         transparencyExpander.add_row(panelColorFixRow);
 
+        // Tray icon inversion for light wallpapers
+        const invertTrayIconsRow = new Adw.SwitchRow({
+            title: _("Invert Tray Icons on Light Wallpapers"),
+            subtitle: _("Darken white monochrome tray icons when the panel adapts to a light wallpaper. Colored icons are left untouched"),
+            active: settings.get_boolean('panel-invert-tray-icons'),
+            sensitive: settings.get_boolean('panel-transparency'),
+        });
+        transparencyExpander.add_row(invertTrayIconsRow);
+
         transparencyGroup.add(transparencyExpander);
 
         // Bindings for expander
@@ -744,6 +754,10 @@ export default class KiwiPreferences extends ExtensionPreferences {
             Gio.SettingsBindFlags.GET);
         settings.bind('panel-color-inherit', panelColorFixRow, 'active',
             Gio.SettingsBindFlags.DEFAULT);
+        settings.bind('panel-invert-tray-icons', invertTrayIconsRow, 'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        settings.bind('panel-transparency', invertTrayIconsRow, 'sensitive',
+            Gio.SettingsBindFlags.GET);
 
         const windowTitleGroup = new Adw.PreferencesGroup();
         panelPage.add(windowTitleGroup);

--- a/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
@@ -109,7 +109,7 @@
         <description>Show the top panel when hovering near the top edge in fullscreen mode.</description>
       </key>
       <key name="panel-transparency" type="b">
-        <default>true</default>
+        <default>false</default>
         <summary>Enable Panel Transparency</summary>
         <description>Make the top panel transparent.</description>
       </key>
@@ -188,6 +188,13 @@
         <default>true</default>
         <summary>Panel Blur</summary>
         <description>Apply a blur effect behind the top panel when it is transparent.</description>
+      </key>
+
+      <!-- Tray icon inversion -->
+      <key name="panel-invert-tray-icons" type="b">
+        <default>false</default>
+        <summary>Invert Tray Icons on Light Wallpapers</summary>
+        <description>Darken white monochrome tray icons when the panel adapts to a light wallpaper. Colored icons are left untouched.</description>
       </key>
 
       <!-- Panel styling -->

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -144,6 +144,67 @@
   padding-right: 10px;
 }
 
+/* Dark foreground for a light wallpaper behind a mostly transparent panel.
+   Toggled by apps/panelTransparency.js. Must stay after the .kiwi-panel-styled
+   rules above — same specificity, so the shadow flip depends on source order. */
+#panel.kiwi-panel-dark-text .panel-button,
+#panel.kiwi-panel-dark-text .panel-button:hover,
+#panel.kiwi-panel-dark-text .panel-button:active,
+#panel.kiwi-panel-dark-text .panel-button:focus,
+#panel.kiwi-panel-dark-text .panel-button:checked,
+#panel.kiwi-panel-dark-text .panel-button StLabel,
+#panel.kiwi-panel-dark-text .panel-button StIcon {
+  color: rgba(0, 0, 0, 0.9);
+}
+
+/* The shadow has to sit on the text nodes themselves — St resolves text-shadow
+   per node, so putting it only on the button leaves the labels flat. */
+#panel.kiwi-panel-dark-text .panel-button,
+#panel.kiwi-panel-dark-text .panel-button:hover,
+#panel.kiwi-panel-dark-text .panel-button:active,
+#panel.kiwi-panel-dark-text .panel-button:focus,
+#panel.kiwi-panel-dark-text .panel-button:checked,
+#panel.kiwi-panel-dark-text .panel-button StLabel,
+#panel.kiwi-panel-dark-text .panel-button .clock,
+#panel.kiwi-panel-dark-text .panel-button .panel-status-menu-box StLabel,
+#panel.kiwi-panel-dark-text .window-title StLabel {
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+#panel.kiwi-panel-dark-text .panel-button .system-status-icon,
+#panel.kiwi-panel-dark-text .panel-button .app-menu-icon > StIcon,
+#panel.kiwi-panel-dark-text .panel-button .popup-menu-arrow {
+  icon-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+/* Hover and active pills: the shell overlays them in white, which vanishes on a
+   light wallpaper. Mirror the shell's own alpha steps in dark. The clock paints
+   its pill on the inner .clock node, so it needs its own selectors. */
+#panel.kiwi-panel-dark-text .panel-button:focus,
+#panel.kiwi-panel-dark-text .panel-button:hover,
+#panel.kiwi-panel-dark-text .panel-button.clock-display:focus .clock,
+#panel.kiwi-panel-dark-text .panel-button.clock-display:hover .clock {
+  box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.17);
+}
+
+#panel.kiwi-panel-dark-text .panel-button:active,
+#panel.kiwi-panel-dark-text .panel-button:checked,
+#panel.kiwi-panel-dark-text .panel-button.clock-display:active .clock,
+#panel.kiwi-panel-dark-text .panel-button.clock-display:checked .clock {
+  box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.28);
+}
+
+#panel.kiwi-panel-dark-text .panel-button:active:hover,
+#panel.kiwi-panel-dark-text .panel-button:checked:hover {
+  box-shadow: inset 0 0 0 100px rgba(0, 0, 0, 0.32);
+}
+
+/* Workspace dots are painted with background-color, so the foreground rules
+   above never reach them. */
+#panel.kiwi-panel-dark-text .panel-button#panelActivities .workspace-dot {
+  background-color: rgba(0, 0, 0, 0.9);
+}
+
 /* Overview mode styles */
 #panel.kiwi-panel-styled:overview {
   background-color: transparent !important;


### PR DESCRIPTION
Implemented panel appindicator monochrome icon automatic switch between dark and light themes. Improves icon visibility. Colored icons stays unaffected. Works with Ubuntu Appindicators extension, which essentially is just a steal of original [AppIndicator and KStatusNotifierItem Support ](https://extensions.gnome.org/extension/615/appindicator-support/). 
Also implemented font color shift based on panel transparency and wallpaper background to improve visibility

<img width="621" height="145" alt="image" src="https://github.com/user-attachments/assets/7964df7d-41e3-4dd7-8c0c-af9f2a3a66c2" />
