### PR TITLE
Support hiding media status indicator and media player

### DIFF
--- a/apps/quickSettingsMedia.js
+++ b/apps/quickSettingsMedia.js
@@ -21,6 +21,7 @@ let quickSettingsGrid = null;
 let _initTimeoutId = null;
 let mediaIndicator = null;
 let gettextFunc = (message) => message;
+let hideMediaIndicator = false;
 
 // Get QuickSettings grid
 function getQuickSettingsGrid() {
@@ -30,6 +31,21 @@ function getQuickSettingsGrid() {
             quickSettingsGrid = quickSettings.menu._grid;
     }
     return quickSettingsGrid;
+}
+
+export function setHideMediaIndicator(enabled) {
+    if (!mediaIndicator)
+        return;
+
+    hideMediaIndicator = enabled;
+
+    if (hideMediaIndicator) {
+        mediaIndicator.visible = false;
+    }
+
+    if (mediaWidget) {
+        mediaWidget._refreshIndicator();
+    }
 }
 
 function ensureMediaIndicator() {
@@ -63,7 +79,7 @@ function updateMediaIndicator({ hasPlayers, isPlaying }) {
     }
 
     const indicator = ensureMediaIndicator();
-    if (!indicator)
+    if (!indicator || hideMediaIndicator)
         return;
 
     indicator.visible = true;

--- a/apps/quickSettingsMedia.js
+++ b/apps/quickSettingsMedia.js
@@ -22,6 +22,7 @@ let _initTimeoutId = null;
 let mediaIndicator = null;
 let gettextFunc = (message) => message;
 let hideMediaIndicator = false;
+let hideMediaPlayer = false;
 
 // Get QuickSettings grid
 function getQuickSettingsGrid() {
@@ -33,11 +34,19 @@ function getQuickSettingsGrid() {
     return quickSettingsGrid;
 }
 
+export function setHideMediaPlayer(enabled) {
+    hideMediaPlayer = enabled;
+
+    if (mediaWidget) {
+        mediaWidget._syncEmpty();
+    }
+}
+
 export function setHideMediaIndicator(enabled) {
+    hideMediaIndicator = enabled;
+
     if (!mediaIndicator)
         return;
-
-    hideMediaIndicator = enabled;
 
     if (hideMediaIndicator) {
         mediaIndicator.visible = false;
@@ -534,7 +543,7 @@ class MediaWidget extends St.BoxLayout {
 
     _syncEmpty() {
         const isEmpty = this._list.empty;
-        this.visible = !isEmpty;
+        this.visible = !isEmpty && !hideMediaPlayer;
         if (isEmpty)
             this._updateBodySpacing(0);
     }
@@ -561,6 +570,7 @@ export function enable(gettext) {
             return GLib.SOURCE_CONTINUE; // Retry if grid not ready
 
         mediaWidget = new MediaWidget();
+        mediaWidget.visible = !hideMediaPlayer;
         const existingChildren = grid.get_children?.() ?? [];
         const notificationsActor = existingChildren.find(child =>
             typeof child.has_style_class_name === 'function' && child.has_style_class_name('kiwi-notifications'));

--- a/extension.js
+++ b/extension.js
@@ -48,7 +48,7 @@ import { enable as dockColorsEnable, disable as dockColorsDisable } from './apps
 import { enable as minimizedToDockEnable, disable as minimizedToDockDisable } from './apps/minimizedToDock.js';
 import { enable as downloadsStackEnable, disable as downloadsStackDisable } from './apps/downloadsStack.js';
 import { enable as reduceWindowAnimationsEnable, disable as reduceWindowAnimationsDisable } from './apps/reduceWindowAnimations.js';
-import { setHideMediaIndicator } from './apps/quickSettingsMedia.js';
+import { setHideMediaIndicator, setHideMediaPlayer } from './apps/quickSettingsMedia.js';
 import { enableDragRestore, disableDragRestore } from './apps/windowTiling.js';
 import { dockActive, isDockExtension } from './apps/dockUtils.js';
 
@@ -203,6 +203,9 @@ export default class KiwiExtension extends Extension {
 
         const hideMediaIndicator = this._settings.get_boolean('hide-media-indicator');
         setHideMediaIndicator(hideMediaIndicator);
+
+        const hideMediaPlayer = this._settings.get_boolean('hide-media-player');
+        setHideMediaPlayer(hideMediaPlayer);
 
         if (this._settings.get_boolean('overview-wallpaper-background')) {
             overviewWallpaperEnable(this._settings);

--- a/extension.js
+++ b/extension.js
@@ -46,6 +46,7 @@ import { enable as dockStylingEnable, disable as dockStylingDisable } from './ap
 import { enable as minimizedToDockEnable, disable as minimizedToDockDisable } from './apps/minimizedToDock.js';
 import { enable as downloadsStackEnable, disable as downloadsStackDisable } from './apps/downloadsStack.js';
 import { enable as reduceWindowAnimationsEnable, disable as reduceWindowAnimationsDisable } from './apps/reduceWindowAnimations.js';
+import { setHideMediaIndicator } from './apps/quickSettingsMedia.js';
 import { enableDragRestore, disableDragRestore } from './apps/windowTiling.js';
 
 export default class KiwiExtension extends Extension {
@@ -193,6 +194,9 @@ export default class KiwiExtension extends Extension {
         } else {
             hideActivitiesButtonDisable();
         }
+
+        const hideMediaIndicator = this._settings.get_boolean('hide-media-indicator');
+        setHideMediaIndicator(hideMediaIndicator);
 
         if (this._settings.get_boolean('overview-wallpaper-background')) {
             overviewWallpaperEnable(this._settings);

--- a/prefs.js
+++ b/prefs.js
@@ -601,6 +601,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
             { key: 'lock-icon', title: _("Caps Lock and Num Lock"), subtitle: _("Show Caps Lock and Num Lock icon") },
             { key: 'custom-dnd-button', title: _("Custom Do Not Disturb Button"), subtitle: _("Replace the system Do Not Disturb button with Kiwi's custom implementation") },
             { key: 'hide-activities-button', title: _("Hide Activities Button"), subtitle: _("Hide the Activities button in the top panel") },
+            { key: 'hide-media-player', title: _("Hide Media Player"), subtitle: _("Hide the Media Player in Quick Settings") },
             { key: 'hide-media-indicator', title: _("Hide Media Status Indicator"), subtitle: _("Hide the Media Status indicator in the quick menu while media is playing") },
             { key: 'add-username-to-quick-menu', title: _("Add Username"), subtitle: _("Add username to the quick menu") },
         ]);

--- a/prefs.js
+++ b/prefs.js
@@ -575,6 +575,7 @@ export default class KiwiPreferences extends ExtensionPreferences {
             { key: 'lock-icon', title: _("Caps Lock and Num Lock"), subtitle: _("Show Caps Lock and Num Lock icon") },
             { key: 'custom-dnd-button', title: _("Custom Do Not Disturb Button"), subtitle: _("Replace the system Do Not Disturb button with Kiwi's custom implementation") },
             { key: 'hide-activities-button', title: _("Hide Activities Button"), subtitle: _("Hide the Activities button in the top panel") },
+            { key: 'hide-media-indicator', title: _("Hide Media Status Indicator"), subtitle: _("Hide the Media Status indicator in the quick menu while media is playing") },
             { key: 'add-username-to-quick-menu', title: _("Add Username"), subtitle: _("Add username to the quick menu") },
         ]);
 

--- a/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
@@ -101,6 +101,11 @@
         <summary>Custom Do Not Disturb Button</summary>
         <description>Replace the system Do Not Disturb quick settings button with Kiwi's custom implementation.</description>
       </key>
+      <key name="hide-media-player" type="b">
+        <default>false</default>
+        <summary>Hide Media Player</summary>
+        <description>Hide the Media Player from Quick Settings</description>
+      </key>
       <key name="hide-media-indicator" type="b">
         <default>false</default>
         <summary>Hide Media Status Indicator</summary>

--- a/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.kiwi.gschema.xml
@@ -101,6 +101,11 @@
         <summary>Custom Do Not Disturb Button</summary>
         <description>Replace the system Do Not Disturb quick settings button with Kiwi's custom implementation.</description>
       </key>
+      <key name="hide-media-indicator" type="b">
+        <default>false</default>
+        <summary>Hide Media Status Indicator</summary>
+        <description>Hide the Media Status indicator in the quick menu while media is playing</description>
+      </key>
       <key name="hide-activities-button" type="b">
         <default>false</default>
         <summary>Hide Activities Button</summary>


### PR DESCRIPTION
Adds feature as described, with a settings entries in the `Panel` section:

<img width="856" height="808" alt="Screenshot From 2026-09-02 18-12-10" src="https://github.com/user-attachments/assets/5ad0f1f8-af5a-457d-b5e8-f0aae45b6c66" />

Media status indicator being hidden:

<img width="2879" height="1799" alt="Screenshot From 2026-08-27 16-08-31" src="https://github.com/user-attachments/assets/a419e467-1489-4573-b3ef-2e946481438f" />

Media player being hidden:

<img width="1344" height="1161" alt="Screenshot From 2026-09-02 18-02-14" src="https://github.com/user-attachments/assets/a6598442-4d2e-4086-a364-509698f159ed" />
